### PR TITLE
Define SPID attribute mappers and remove hardcoded mapping logic

### DIFF
--- a/docker/themes/base/admin/resources/partials/realm-identity-provider-spid.html
+++ b/docker/themes/base/admin/resources/partials/realm-identity-provider-spid.html
@@ -22,7 +22,7 @@
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="identifier"><span class="required">*</span> {{:: 'alias' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" id="identifier" type="text" ng-model="identityProvider.alias" data-ng-readonly="!newIdentityProvider" required>
+                    <input kc-no-reserved-chars class="form-control" id="identifier" type="text" ng-model="identityProvider.alias" data-ng-readonly="!newIdentityProvider" required>
                 </div>
                 <kc-tooltip>{{:: 'identity-provider.alias.tooltip' | translate}}</kc-tooltip>
             </div>
@@ -142,6 +142,22 @@
                 </div>
                 <kc-tooltip>{{:: 'nameid-policy-format.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group clearfix">
+                <label class="col-md-2 control-label" for="principalType">{{:: 'saml.principal-type' | translate}}</label>
+                <div class="col-md-6">
+                    <select id="principalType" ng-model="identityProvider.config.principalType"
+                            ng-options="pType.type as pType.name for pType in principalTypes">
+                     </select>
+                </div>
+                <kc-tooltip>{{:: 'saml.principal-type.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group clearfix" data-ng-show="identityProvider.config.principalType.endsWith('ATTRIBUTE')">
+                <label class="col-md-2 control-label" for="principalAttribute">{{:: 'saml.principal-attribute' | translate}}</label>
+                <div class="col-md-6">
+                    <input class="form-control" id="principalAttribute" type="text" ng-model="identityProvider.config.principalAttribute" ng-required="identityProvider.config.principalType.endsWith('ATTRIBUTE')">
+                </div>
+                <kc-tooltip>{{:: 'saml.principal-attribute.tooltip' | translate}}</kc-tooltip>
+            </div>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="postBindingResponse">{{:: 'http-post-binding-response' | translate}}</label>
                 <div class="col-md-6">
@@ -228,6 +244,13 @@
                     <textarea class="form-control" id="signingCertificate" ng-model="identityProvider.config.signingCertificate"/>
                 </div>
                 <kc-tooltip>{{:: 'validating-x509-certificate.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="allowedClockSkew">{{:: 'allowed-clock-skew' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" string-to-number type="number" min="0" max="2147483" step="1" ng-model="identityProvider.config.allowedClockSkew" id="allowedClockSkew"/>
+                </div>
+                <kc-tooltip>{{:: 'identity-provider.allowed-clock-skew.tooltip' | translate}}</kc-tooltip>
             </div>
          </fieldset>
         <fieldset data-ng-show="newIdentityProvider">

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/redhat-italy/keycloak-spid-provider</url>
 
     <properties>
-        <version.keycloak>4.8.3.Final</version.keycloak>
+        <version.keycloak>9.0.2</version.keycloak>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/src/main/java/it/redhat/spid/provider/SpidIdentityProviderFactory.java
+++ b/src/main/java/it/redhat/spid/provider/SpidIdentityProviderFactory.java
@@ -60,6 +60,11 @@ public class SpidIdentityProviderFactory extends AbstractIdentityProviderFactory
     }
 
     @Override
+    public SpidIdentityProviderConfig createConfig() {
+        return new SpidIdentityProviderConfig();
+    }
+
+    @Override
     public Map<String, String> parseConfig(KeycloakSession session, InputStream inputStream) {
         try {
             Object parsedObject = SAMLParser.getInstance().parse(inputStream);
@@ -156,7 +161,7 @@ public class SpidIdentityProviderFactory extends AbstractIdentityProviderFactory
             throw new RuntimeException("Could not parse IdP SAML Metadata", pe);
         }
 
-        return new HashMap<String, String>();
+        return new HashMap<>();
     }
 
     @Override

--- a/src/main/java/it/redhat/spid/provider/SpidSAMLEndpoint.java
+++ b/src/main/java/it/redhat/spid/provider/SpidSAMLEndpoint.java
@@ -22,9 +22,6 @@ import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.provider.IdentityProvider;
-import org.keycloak.broker.saml.SAMLEndpoint;
-import org.keycloak.broker.saml.SAMLIdentityProvider;
-import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.VerificationException;
 import org.keycloak.dom.saml.v2.assertion.*;
@@ -83,7 +80,7 @@ import java.util.*;
  * @version $Revision: 1 $
  */
 public class SpidSAMLEndpoint {
-    protected static final Logger logger = Logger.getLogger(SAMLEndpoint.class);
+    protected static final Logger logger = Logger.getLogger(SpidSAMLEndpoint.class);
     public static final String SAML_FEDERATED_SESSION_INDEX = "SAML_FEDERATED_SESSION_INDEX";
     public static final String SAML_FEDERATED_SUBJECT = "SAML_FEDERATED_SUBJECT";
     public static final String SAML_FEDERATED_SUBJECT_NAMEFORMAT = "SAML_FEDERATED_SUBJECT_NAMEFORMAT";
@@ -299,7 +296,7 @@ public class SpidSAMLEndpoint {
             builder.logoutRequestID(request.getID());
             builder.destination(config.getSingleLogoutServiceUrl());
             builder.issuer(issuerURL);
-            JaxrsSAML2BindingBuilder binding = new JaxrsSAML2BindingBuilder()
+            JaxrsSAML2BindingBuilder binding = new JaxrsSAML2BindingBuilder(session)
                     .relayState(relayState);
             boolean postBinding = config.isPostBindingLogout();
             if (config.isWantAuthnRequestsSigned()) {

--- a/src/main/java/it/redhat/spid/provider/SpidSAMLEndpoint.java
+++ b/src/main/java/it/redhat/spid/provider/SpidSAMLEndpoint.java
@@ -434,28 +434,6 @@ public class SpidSAMLEndpoint {
 
                 identity.setUsername(subjectNameID.getValue());
 
-                //@spid: set username with spidCode
-                Set<AttributeStatementType> attributeStatements = assertion.getAttributeStatements();
-                for (AttributeStatementType next : attributeStatements) {
-                    List<AttributeStatementType.ASTChoiceType> attributes = next.getAttributes();
-                    for (AttributeStatementType.ASTChoiceType astChoiceType : attributes) {
-                        String name = astChoiceType.getAttribute().getName();
-                        if (name.equals("spidCode")) {
-                            //identity.setUsername(astChoiceType.getAttribute().getAttributeValue().get(0).toString());
-                        }
-
-                        if (name.equals("email")) {
-                            identity.setEmail(astChoiceType.getAttribute().getAttributeValue().get(0).toString());
-                        }
-                        
-                    }
-                }
-
-                //@spid: Static set for flawless login
-                identity.setName("Name");
-                identity.setFirstName("First Name");
-                identity.setLastName("Last Name");
-
                 //SAML Spec 2.2.2 Format is optional
                 if (subjectNameID.getFormat() != null && subjectNameID.getFormat().toString().equals(JBossSAMLURIConstants.NAMEID_FORMAT_EMAIL.get())) {
                     identity.setEmail(subjectNameID.getValue());

--- a/src/main/java/it/redhat/spid/provider/SpidSAMLEndpoint.java
+++ b/src/main/java/it/redhat/spid/provider/SpidSAMLEndpoint.java
@@ -19,12 +19,18 @@ package it.redhat.spid.provider;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
+
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.provider.IdentityProvider;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.VerificationException;
-import org.keycloak.dom.saml.v2.assertion.*;
+import org.keycloak.dom.saml.v2.assertion.AssertionType;
+import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
+import org.keycloak.dom.saml.v2.assertion.AttributeType;
+import org.keycloak.dom.saml.v2.assertion.AuthnStatementType;
+import org.keycloak.dom.saml.v2.assertion.NameIDType;
+import org.keycloak.dom.saml.v2.assertion.SubjectType;
 import org.keycloak.dom.saml.v2.protocol.LogoutRequestType;
 import org.keycloak.dom.saml.v2.protocol.RequestAbstractType;
 import org.keycloak.dom.saml.v2.protocol.ResponseType;
@@ -40,8 +46,8 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.saml.JaxrsSAML2BindingBuilder;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.protocol.saml.SamlProtocolUtils;
-import org.keycloak.rotation.HardcodedKeyLocator;
-import org.keycloak.rotation.KeyLocator;
+import org.keycloak.protocol.saml.SamlSessionUtils;
+import org.keycloak.protocol.saml.preprocessor.SamlAuthenticationPreprocessor;
 import org.keycloak.saml.SAML2LogoutResponseBuilder;
 import org.keycloak.saml.SAMLRequestParser;
 import org.keycloak.saml.common.constants.GeneralConstants;
@@ -53,27 +59,47 @@ import org.keycloak.saml.common.util.DocumentUtil;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import org.keycloak.saml.processing.core.saml.v2.constants.X500SAMLProfileConstants;
 import org.keycloak.saml.processing.core.saml.v2.util.AssertionUtil;
-import org.keycloak.saml.processing.core.util.KeycloakKeySamlExtensionGenerator;
 import org.keycloak.saml.processing.core.util.XMLSignatureUtil;
 import org.keycloak.saml.processing.web.util.PostBindingUtil;
-import org.keycloak.saml.validators.ConditionsValidator;
-import org.keycloak.saml.validators.DestinationValidator;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import javax.xml.crypto.dsig.XMLSignature;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import javax.xml.namespace.QName;
 import java.io.IOException;
-import java.net.URI;
 import java.security.Key;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.function.Predicate;
+
+import org.keycloak.protocol.saml.SamlPrincipalType;
+import org.keycloak.rotation.HardcodedKeyLocator;
+import org.keycloak.rotation.KeyLocator;
+import org.keycloak.saml.processing.core.util.KeycloakKeySamlExtensionGenerator;
+import org.keycloak.saml.validators.ConditionsValidator;
+import org.keycloak.saml.validators.DestinationValidator;
+import java.net.URI;
+import java.security.cert.CertificateException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
 import java.util.*;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.xml.crypto.dsig.XMLSignature;
+import org.w3c.dom.NodeList;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -82,8 +108,11 @@ import java.util.*;
 public class SpidSAMLEndpoint {
     protected static final Logger logger = Logger.getLogger(SpidSAMLEndpoint.class);
     public static final String SAML_FEDERATED_SESSION_INDEX = "SAML_FEDERATED_SESSION_INDEX";
+    @Deprecated // in favor of SAML_FEDERATED_SUBJECT_NAMEID
     public static final String SAML_FEDERATED_SUBJECT = "SAML_FEDERATED_SUBJECT";
+    @Deprecated // in favor of SAML_FEDERATED_SUBJECT_NAMEID
     public static final String SAML_FEDERATED_SUBJECT_NAMEFORMAT = "SAML_FEDERATED_SUBJECT_NAMEFORMAT";
+    public static final String SAML_FEDERATED_SUBJECT_NAMEID = "SAML_FEDERATED_SUBJECT_NAME_ID";
     public static final String SAML_LOGIN_RESPONSE = "SAML_LOGIN_RESPONSE";
     public static final String SAML_ASSERTION = "SAML_ASSERTION";
     public static final String SAML_IDP_INITIATED_CLIENT_ID = "SAML_IDP_INITIATED_CLIENT_ID";
@@ -123,7 +152,7 @@ public class SpidSAMLEndpoint {
     @GET
     public Response redirectBinding(@QueryParam(GeneralConstants.SAML_REQUEST_KEY) String samlRequest,
                                     @QueryParam(GeneralConstants.SAML_RESPONSE_KEY) String samlResponse,
-                                    @QueryParam(GeneralConstants.RELAY_STATE) String relayState) {
+                                    @QueryParam(GeneralConstants.RELAY_STATE) String relayState)  {
         return new RedirectBinding().execute(samlRequest, samlResponse, relayState, null);
     }
 
@@ -143,7 +172,7 @@ public class SpidSAMLEndpoint {
     public Response redirectBinding(@QueryParam(GeneralConstants.SAML_REQUEST_KEY) String samlRequest,
                                     @QueryParam(GeneralConstants.SAML_RESPONSE_KEY) String samlResponse,
                                     @QueryParam(GeneralConstants.RELAY_STATE) String relayState,
-                                    @PathParam("client_id") String clientId) {
+                                    @PathParam("client_id") String clientId)  {
         return new RedirectBinding().execute(samlRequest, samlResponse, relayState, clientId);
     }
 
@@ -191,11 +220,9 @@ public class SpidSAMLEndpoint {
         }
 
         protected abstract String getBindingType();
-
+        protected abstract boolean containsUnencryptedSignature(SAMLDocumentHolder documentHolder);
         protected abstract void verifySignature(String key, SAMLDocumentHolder documentHolder) throws VerificationException;
-
         protected abstract SAMLDocumentHolder extractRequestDocument(String samlRequest);
-
         protected abstract SAMLDocumentHolder extractResponseDocument(String response);
 
         protected KeyLocator getIDPKeyLocator() {
@@ -229,7 +256,7 @@ public class SpidSAMLEndpoint {
             SAMLDocumentHolder holder = extractRequestDocument(samlRequest);
             RequestAbstractType requestAbstractType = (RequestAbstractType) holder.getSamlObject();
             // validate destination
-            if (!destinationValidator.validate(session.getContext().getUri().getAbsolutePath(), requestAbstractType.getDestination())) {
+            if (! destinationValidator.validate(session.getContext().getUri().getAbsolutePath(), requestAbstractType.getDestination())) {
                 event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                 event.detail(Details.REASON, "invalid_destination");
                 event.error(Errors.INVALID_SAML_RESPONSE);
@@ -267,6 +294,11 @@ public class SpidSAMLEndpoint {
                     if (userSession.getState() == UserSessionModel.State.LOGGING_OUT || userSession.getState() == UserSessionModel.State.LOGGED_OUT) {
                         continue;
                     }
+
+                    for(Iterator<SamlAuthenticationPreprocessor> it = SamlSessionUtils.getSamlAuthenticationPreprocessorIterator(session); it.hasNext();) {
+                        request = it.next().beforeProcessingLogoutRequest(request, userSession, null);
+                    }
+
                     try {
                         AuthenticationManager.backchannelLogout(session, realm, userSession, session.getContext().getUri(), clientConnection, headers, false);
                     } catch (Exception e) {
@@ -274,7 +306,7 @@ public class SpidSAMLEndpoint {
                     }
                 }
 
-            } else {
+            }  else {
                 for (String sessionIndex : request.getSessionIndex()) {
                     String brokerSessionId = brokerUserId + "." + sessionIndex;
                     UserSessionModel userSession = session.sessions().getUserSessionByBrokerSessionId(realm, brokerSessionId);
@@ -282,6 +314,11 @@ public class SpidSAMLEndpoint {
                         if (userSession.getState() == UserSessionModel.State.LOGGING_OUT || userSession.getState() == UserSessionModel.State.LOGGED_OUT) {
                             continue;
                         }
+
+                        for(Iterator<SamlAuthenticationPreprocessor> it = SamlSessionUtils.getSamlAuthenticationPreprocessorIterator(session); it.hasNext();) {
+                            request = it.next().beforeProcessingLogoutRequest(request, userSession, null);
+                        }
+
                         try {
                             AuthenticationManager.backchannelLogout(session, realm, userSession, session.getContext().getUri(), clientConnection, headers, false);
                         } catch (Exception e) {
@@ -297,7 +334,7 @@ public class SpidSAMLEndpoint {
             builder.destination(config.getSingleLogoutServiceUrl());
             builder.issuer(issuerURL);
             JaxrsSAML2BindingBuilder binding = new JaxrsSAML2BindingBuilder(session)
-                    .relayState(relayState);
+                        .relayState(relayState);
             boolean postBinding = config.isPostBindingLogout();
             if (config.isWantAuthnRequestsSigned()) {
                 KeyManager.ActiveRsaKey keys = session.keys().getActiveRsaKey(realm);
@@ -305,7 +342,7 @@ public class SpidSAMLEndpoint {
                 binding.signWith(keyName, keys.getPrivateKey(), keys.getPublicKey(), keys.getCertificate())
                         .signatureAlgorithm(provider.getSignatureAlgorithm())
                         .signDocument();
-                if (!postBinding && config.isAddExtensionsElementWithKeyInfo()) {    // Only include extension if REDIRECT binding and signing whole SAML protocol message
+                if (! postBinding && config.isAddExtensionsElementWithKeyInfo()) {    // Only include extension if REDIRECT binding and signing whole SAML protocol message
                     builder.addExtension(new KeycloakKeySamlExtensionGenerator(keyName));
                 }
             }
@@ -333,7 +370,7 @@ public class SpidSAMLEndpoint {
 
             try {
                 KeyManager.ActiveRsaKey keys = session.keys().getActiveRsaKey(realm);
-                if (!isSuccessfulSamlResponse(responseType)) {
+                if (! isSuccessfulSamlResponse(responseType)) {
                     String statusMessage = responseType.getStatus() == null ? Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR : responseType.getStatus().getStatusMessage();
                     return callback.error(relayState, statusMessage);
                 }
@@ -362,8 +399,11 @@ public class SpidSAMLEndpoint {
                 }
 
                 boolean signed = AssertionUtil.isSignedElement(assertionElement);
-                if ((config.isWantAssertionsSigned() && !signed)
-                        || (signed && config.isValidateSignature() && !AssertionUtil.isSignatureValid(assertionElement, getIDPKeyLocator()))) {
+                final boolean assertionSignatureNotExistsWhenRequired = config.isWantAssertionsSigned() && !signed;
+                final boolean signatureNotValid = signed && config.isValidateSignature() && !AssertionUtil.isSignatureValid(assertionElement, getIDPKeyLocator());
+                final boolean hasNoSignatureWhenRequired = ! signed && config.isValidateSignature() && ! containsUnencryptedSignature(holder);
+
+                if (assertionSignatureNotExistsWhenRequired || signatureNotValid || hasNoSignatureWhenRequired) {
                     logger.error("validation failed");
                     event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                     event.error(Errors.INVALID_SIGNATURE);
@@ -375,11 +415,20 @@ public class SpidSAMLEndpoint {
                 SubjectType subject = assertion.getSubject();
                 SubjectType.STSubType subType = subject.getSubType();
                 NameIDType subjectNameID = (NameIDType) subType.getBaseID();
+                String principal = getPrincipal(assertion);
+
+                if (principal == null) {
+                    logger.errorf("no principal in assertion; expected: %s", expectedPrincipalType());
+                    event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
+                    event.error(Errors.INVALID_SAML_RESPONSE);
+                    return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUESTER);
+                }
+
                 //Map<String, String> notes = new HashMap<>();
                 BrokeredIdentityContext identity = new BrokeredIdentityContext(subjectNameID.getValue());
                 identity.getContextData().put(SAML_LOGIN_RESPONSE, responseType);
                 identity.getContextData().put(SAML_ASSERTION, assertion);
-                if (clientId != null && !clientId.trim().isEmpty()) {
+                if (clientId != null && ! clientId.trim().isEmpty()) {
                     identity.getContextData().put(SAML_IDP_INITIATED_CLIENT_ID, clientId);
                 }
 
@@ -407,8 +456,6 @@ public class SpidSAMLEndpoint {
                 identity.setFirstName("First Name");
                 identity.setLastName("Last Name");
 
-
-
                 //SAML Spec 2.2.2 Format is optional
                 if (subjectNameID.getFormat() != null && subjectNameID.getFormat().toString().equals(JBossSAMLURIConstants.NAMEID_FORMAT_EMAIL.get())) {
                     identity.setEmail(subjectNameID.getValue());
@@ -418,7 +465,8 @@ public class SpidSAMLEndpoint {
                     identity.setToken(samlResponse);
                 }
 
-                ConditionsValidator.Builder cvb = new ConditionsValidator.Builder(assertion.getID(), assertion.getConditions(), destinationValidator);
+                ConditionsValidator.Builder cvb = new ConditionsValidator.Builder(assertion.getID(), assertion.getConditions(), destinationValidator)
+                        .clockSkewInMillis(1000 * config.getAllowedClockSkew());
                 try {
                     String issuerURL = getEntityId(session.getContext().getUri(), realm);
                     cvb.addAllowedAudience(URI.create(issuerURL));
@@ -429,7 +477,7 @@ public class SpidSAMLEndpoint {
                 } catch (IllegalArgumentException ex) {
                     // warning has been already emitted in DeploymentBuilder
                 }
-                if (!cvb.build().isValid()) {
+                if (! cvb.build().isValid()) {
                     logger.error("Assertion expired.");
                     event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                     event.error(Errors.INVALID_SAML_RESPONSE);
@@ -439,32 +487,24 @@ public class SpidSAMLEndpoint {
                 AuthnStatementType authn = null;
                 for (Object statement : assertion.getStatements()) {
                     if (statement instanceof AuthnStatementType) {
-                        authn = (AuthnStatementType) statement;
+                        authn = (AuthnStatementType)statement;
                         identity.getContextData().put(SAML_AUTHN_STATEMENT, authn);
                         break;
                     }
                 }
-                if (assertion.getAttributeStatements() != null) {
-                    for (AttributeStatementType attrStatement : assertion.getAttributeStatements()) {
-                        for (AttributeStatementType.ASTChoiceType choice : attrStatement.getAttributes()) {
-                            AttributeType attribute = choice.getAttribute();
-                            if (X500SAMLProfileConstants.EMAIL.getFriendlyName().equals(attribute.getFriendlyName())
-                                    || X500SAMLProfileConstants.EMAIL.get().equals(attribute.getName())) {
-                                if (!attribute.getAttributeValue().isEmpty())
-                                    identity.setEmail(attribute.getAttributeValue().get(0).toString());
-                            }
-                        }
-
-                    }
-
+                if (assertion.getAttributeStatements() != null ) {
+                    String email = getX500Attribute(assertion, X500SAMLProfileConstants.EMAIL);
+                    if (email != null)
+                        identity.setEmail(email);
                 }
+
                 String brokerUserId = config.getAlias() + "." + subjectNameID.getValue();
                 identity.setBrokerUserId(brokerUserId);
                 identity.setIdpConfig(config);
                 identity.setIdp(provider);
                 if (authn != null && authn.getSessionIndex() != null) {
                     identity.setBrokerSessionId(identity.getBrokerUserId() + "." + authn.getSessionIndex());
-                }
+                 }
                 identity.setCode(relayState);
 
 
@@ -479,18 +519,24 @@ public class SpidSAMLEndpoint {
 
         private boolean isSuccessfulSamlResponse(ResponseType responseType) {
             return responseType != null
-                    && responseType.getStatus() != null
-                    && responseType.getStatus().getStatusCode() != null
-                    && responseType.getStatus().getStatusCode().getValue() != null
-                    && Objects.equals(responseType.getStatus().getStatusCode().getValue().toString(), JBossSAMLURIConstants.STATUS_SUCCESS.get());
+              && responseType.getStatus() != null
+              && responseType.getStatus().getStatusCode() != null
+              && responseType.getStatus().getStatusCode().getValue() != null
+              && Objects.equals(responseType.getStatus().getStatusCode().getValue().toString(), JBossSAMLURIConstants.STATUS_SUCCESS.get());
         }
 
 
         public Response handleSamlResponse(String samlResponse, String relayState, String clientId) {
             SAMLDocumentHolder holder = extractResponseDocument(samlResponse);
-            StatusResponseType statusResponse = (StatusResponseType) holder.getSamlObject();
+            if (holder == null) {
+                event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
+                event.detail(Details.REASON, "invalid_saml_document");
+                event.error(Errors.INVALID_SAML_RESPONSE);
+                return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_FEDERATED_IDENTITY_ACTION);
+            }
+            StatusResponseType statusResponse = (StatusResponseType)holder.getSamlObject();
             // validate destination
-            if (!destinationValidator.validate(session.getContext().getUri().getAbsolutePath(), statusResponse.getDestination())) {
+            if (! destinationValidator.validate(session.getContext().getUri().getAbsolutePath(), statusResponse.getDestination())) {
                 event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                 event.detail(Details.REASON, "invalid_destination");
                 event.error(Errors.INVALID_SAML_RESPONSE);
@@ -507,7 +553,7 @@ public class SpidSAMLEndpoint {
                 }
             }
             if (statusResponse instanceof ResponseType) {
-                return handleLoginResponse(samlResponse, holder, (ResponseType) statusResponse, relayState, clientId);
+                return handleLoginResponse(samlResponse, holder, (ResponseType)statusResponse, relayState, clientId);
 
             } else {
                 // todo need to check that it is actually a LogoutResponse
@@ -541,17 +587,24 @@ public class SpidSAMLEndpoint {
         }
 
 
+
+
+
     }
 
     protected class PostBinding extends Binding {
         @Override
-        protected void verifySignature(String key, SAMLDocumentHolder documentHolder) throws VerificationException {
+        protected boolean containsUnencryptedSignature(SAMLDocumentHolder documentHolder) {
             NodeList nl = documentHolder.getSamlDocument().getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
-            boolean anyElementSigned = (nl != null && nl.getLength() > 0);
-            if ((!anyElementSigned) && (documentHolder.getSamlObject() instanceof ResponseType)) {
+            return (nl != null && nl.getLength() > 0);
+        }
+
+        @Override
+        protected void verifySignature(String key, SAMLDocumentHolder documentHolder) throws VerificationException {
+            if ((! containsUnencryptedSignature(documentHolder)) && (documentHolder.getSamlObject() instanceof ResponseType)) {
                 ResponseType responseType = (ResponseType) documentHolder.getSamlObject();
                 List<ResponseType.RTChoiceType> assertions = responseType.getAssertions();
-                if (!assertions.isEmpty()) {
+                if (! assertions.isEmpty() ) {
                     // Only relax verification if the response is an authnresponse and contains (encrypted/plaintext) assertion.
                     // In that case, signature is validated on assertion element
                     return;
@@ -564,7 +617,6 @@ public class SpidSAMLEndpoint {
         protected SAMLDocumentHolder extractRequestDocument(String samlRequest) {
             return SAMLRequestParser.parseRequestPostBinding(samlRequest);
         }
-
         @Override
         protected SAMLDocumentHolder extractResponseDocument(String response) {
             byte[] samlBytes = PostBindingUtil.base64Decode(response);
@@ -579,10 +631,19 @@ public class SpidSAMLEndpoint {
 
     protected class RedirectBinding extends Binding {
         @Override
+        protected boolean containsUnencryptedSignature(SAMLDocumentHolder documentHolder) {
+            MultivaluedMap<String, String> encodedParams = session.getContext().getUri().getQueryParameters(false);
+            String algorithm = encodedParams.getFirst(GeneralConstants.SAML_SIG_ALG_REQUEST_KEY);
+            String signature = encodedParams.getFirst(GeneralConstants.SAML_SIGNATURE_REQUEST_KEY);
+            return algorithm != null && signature != null;
+        }
+
+        @Override
         protected void verifySignature(String key, SAMLDocumentHolder documentHolder) throws VerificationException {
             KeyLocator locator = getIDPKeyLocator();
             SamlProtocolUtils.verifyRedirectSignature(documentHolder, locator, session.getContext().getUri(), key);
         }
+
 
 
         @Override
@@ -600,6 +661,61 @@ public class SpidSAMLEndpoint {
             return SamlProtocol.SAML_REDIRECT_BINDING;
         }
 
+    }
+
+    private String getX500Attribute(AssertionType assertion, X500SAMLProfileConstants attribute) {
+        return getFirstMatchingAttribute(assertion, attribute::correspondsTo);
+    }
+
+    private String getAttributeByName(AssertionType assertion, String name) {
+        return getFirstMatchingAttribute(assertion, attribute -> Objects.equals(attribute.getName(), name));
+    }
+
+    private String getAttributeByFriendlyName(AssertionType assertion, String friendlyName) {
+        return getFirstMatchingAttribute(assertion, attribute -> Objects.equals(attribute.getFriendlyName(), friendlyName));
+    }
+
+    private String getPrincipal(AssertionType assertion) {
+
+        SamlPrincipalType principalType = config.getPrincipalType();
+
+        if (principalType == null || principalType.equals(SamlPrincipalType.SUBJECT)) {
+            SubjectType subject = assertion.getSubject();
+            SubjectType.STSubType subType = subject.getSubType();
+            NameIDType subjectNameID = (NameIDType) subType.getBaseID();
+            return subjectNameID.getValue();
+        } else if (principalType.equals(SamlPrincipalType.ATTRIBUTE)) {
+            return getAttributeByName(assertion, config.getPrincipalAttribute());
+        } else {
+            return getAttributeByFriendlyName(assertion, config.getPrincipalAttribute());
+        }
+
+    }
+
+    private String getFirstMatchingAttribute(AssertionType assertion, Predicate<AttributeType> predicate) {
+        return assertion.getAttributeStatements().stream()
+                .map(AttributeStatementType::getAttributes)
+                .flatMap(Collection::stream)
+                .map(AttributeStatementType.ASTChoiceType::getAttribute)
+                .filter(predicate)
+                .map(AttributeType::getAttributeValue)
+                .flatMap(Collection::stream)
+                .findFirst()
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    private String expectedPrincipalType() {
+        SamlPrincipalType principalType = config.getPrincipalType();
+        switch (principalType) {
+            case SUBJECT:
+                return principalType.name();
+            case ATTRIBUTE:
+            case FRIENDLY_ATTRIBUTE:
+                return String.format("%s(%s)", principalType.name(), config.getPrincipalAttribute());
+            default:
+                return null;
+        }
     }
 
 }

--- a/src/main/java/it/redhat/spid/saml/SpidSAML2AuthnRequestBuilder.java
+++ b/src/main/java/it/redhat/spid/saml/SpidSAML2AuthnRequestBuilder.java
@@ -80,11 +80,10 @@ public class SpidSAML2AuthnRequestBuilder implements SamlProtocolExtensionsAware
         return this;
     }
 
-    /*
     public SpidSAML2AuthnRequestBuilder isPassive(boolean isPassive) {
         this.authnRequestType.setIsPassive(isPassive);
         return this;
-    }*/
+    }
 
     public SpidSAML2AuthnRequestBuilder nameIdPolicy(SAML2NameIDPolicyBuilder nameIDPolicy) {
         this.authnRequestType.setNameIDPolicy(nameIDPolicy.build());
@@ -113,6 +112,12 @@ public class SpidSAML2AuthnRequestBuilder implements SamlProtocolExtensionsAware
         NameIDType nameIDType = new NameIDType();
 
         nameIDType.setValue(this.issuer);
+
+        // SPID: Aggiungi l'attributo NameQualifier all'elemento Issuer
+        nameIDType.setNameQualifier(this.issuer);
+
+        // SPID: Aggiungi l'attributo Format all'elemento Issuer
+        nameIDType.setFormat(JBossSAMLURIConstants.NAMEID_FORMAT_ENTITY.getUri());
 
         res.setIssuer(nameIDType);
 

--- a/src/main/java/it/redhat/spid/saml/SpidSAML2AuthnRequestBuilder.java
+++ b/src/main/java/it/redhat/spid/saml/SpidSAML2AuthnRequestBuilder.java
@@ -98,33 +98,38 @@ public class SpidSAML2AuthnRequestBuilder implements SamlProtocolExtensionsAware
 
     public Document toDocument() {
         try {
-            
-            AuthnRequestType authnRequestType = this.authnRequestType;
-
-            NameIDType nameIDType = new NameIDType();
-
-            nameIDType.setValue(this.issuer);
-
-            authnRequestType.setIssuer(nameIDType);
-
-            String hostDestination = getDestinationHost(this.destination);
-            
-            authnRequestType.setDestination(URI.create(hostDestination));
-            
-
-            if (!this.extensions.isEmpty()) {
-                ExtensionsType extensionsType = new ExtensionsType();
-                for (NodeGenerator extension : this.extensions) {
-                    extensionsType.addExtension(extension);
-                }
-                authnRequestType.setExtensions(extensionsType);
-            }
+            AuthnRequestType authnRequestType = createAuthnRequest();
 
             return new SpidSAML2Request().convert(authnRequestType);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Could not convert " + authnRequestType + " to a document.", e);
         }
+    }
+         
+    public AuthnRequestType createAuthnRequest() {
+        AuthnRequestType res = this.authnRequestType;
+
+        NameIDType nameIDType = new NameIDType();
+
+        nameIDType.setValue(this.issuer);
+
+        res.setIssuer(nameIDType);
+
+        String hostDestination = getDestinationHost(this.destination);
+            
+        res.setDestination(URI.create(hostDestination));
+            
+
+        if (!this.extensions.isEmpty()) {
+            ExtensionsType extensionsType = new ExtensionsType();
+            for (NodeGenerator extension : this.extensions) {
+                extensionsType.addExtension(extension);
+            }
+            res.setExtensions(extensionsType);
+        }
+
+        return res;
     }
 
     private String getDestinationHost(String destination) {

--- a/src/main/java/it/redhat/spid/saml/SpidSAML2Request.java
+++ b/src/main/java/it/redhat/spid/saml/SpidSAML2Request.java
@@ -60,7 +60,6 @@ import java.net.URL;
  * @since Jan 5, 2009
  */
 public class SpidSAML2Request {
-
     private static final PicketLinkLogger logger = PicketLinkLoggerFactory.getLogger();
 
     private SAMLDocumentHolder samlDocumentHolder = null;
@@ -77,7 +76,7 @@ public class SpidSAML2Request {
     }
 
     /**
-     * Create an authentication request
+     * Create authentication request with protocolBinding defaulting to POST
      *
      * @param id
      * @param assertionConsumerURL
@@ -88,11 +87,29 @@ public class SpidSAML2Request {
      */
     public AuthnRequestType createAuthnRequestType(String id, String assertionConsumerURL, String destination,
                                                    String issuerValue) throws ConfigurationException {
+        return createAuthnRequestType(id, assertionConsumerURL, destination, issuerValue, JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri());
+    }
+
+    /**
+     * Create an authentication request
+     *
+     * @param id
+     * @param assertionConsumerURL
+     * @param destination
+     * @param issuerValue
+     * @param protocolBindingUri
+     *
+     * @return
+     *
+     * @throws ConfigurationException
+     */
+    public AuthnRequestType createAuthnRequestType(String id, String assertionConsumerURL, String destination,
+                                                   String issuerValue, URI protocolBinding) throws ConfigurationException {
         XMLGregorianCalendar issueInstant = XMLTimeUtil.getIssueInstant();
 
         AuthnRequestType authnRequest = new AuthnRequestType(id, issueInstant);
         authnRequest.setAssertionConsumerServiceURL(URI.create(assertionConsumerURL));
-        authnRequest.setProtocolBinding(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri());
+        authnRequest.setProtocolBinding(protocolBinding);
         if (destination != null) {
             authnRequest.setDestination(URI.create(destination));
         }
@@ -123,13 +140,15 @@ public class SpidSAML2Request {
      * Get AuthnRequestType from a file
      *
      * @param fileName file with the serialized AuthnRequestType
+     *
      * @return AuthnRequestType
+     *
      * @throws ParsingException
      * @throws ProcessingException
      * @throws ConfigurationException
      * @throws IllegalArgumentException if the input fileName is null IllegalStateException if the InputStream from the
-     *                                  fileName
-     *                                  is null
+     * fileName
+     * is null
      */
     public AuthnRequestType getAuthnRequestType(String fileName) throws ConfigurationException, ProcessingException,
             ParsingException {
@@ -152,7 +171,9 @@ public class SpidSAML2Request {
      * Get the Underlying SAML2Object from the input stream
      *
      * @param is
+     *
      * @return
+     *
      * @throws IOException
      * @throws ParsingException
      */
@@ -174,7 +195,9 @@ public class SpidSAML2Request {
      * Get a Request Type from Input Stream
      *
      * @param is
+     *
      * @return
+     *
      * @throws ProcessingException
      * @throws ConfigurationException
      * @throws
@@ -199,7 +222,9 @@ public class SpidSAML2Request {
      * Get the AuthnRequestType from an input stream
      *
      * @param is Inputstream containing the AuthnRequest
+     *
      * @return
+     *
      * @throws ParsingException
      * @throws ProcessingException
      * @throws ConfigurationException
@@ -233,7 +258,9 @@ public class SpidSAML2Request {
      * Create a Logout Request
      *
      * @param issuer
+     *
      * @return
+     *
      * @throws ConfigurationException
      */
     public static LogoutRequestType createLogoutRequest(String issuer) throws ConfigurationException {
@@ -252,7 +279,9 @@ public class SpidSAML2Request {
      * Return the DOM object
      *
      * @param rat
+     *
      * @return
+     *
      * @throws ProcessingException
      * @throws ParsingException
      * @throws ConfigurationException
@@ -278,7 +307,9 @@ public class SpidSAML2Request {
      * Convert a SAML2 Response into a Document
      *
      * @param responseType
+     *
      * @return
+     *
      * @throws ProcessingException
      * @throws ParsingException
      * @throws ConfigurationException
@@ -297,14 +328,15 @@ public class SpidSAML2Request {
      *
      * @param requestType
      * @param os
+     *
      * @throws ProcessingException
      */
     public static void marshall(RequestAbstractType requestType, OutputStream os) throws ProcessingException {
-        SpidSAMLRequestWriter SpidSAMLRequestWriter = new SpidSAMLRequestWriter(StaxUtil.getXMLStreamWriter(os));
+        SpidSAMLRequestWriter samlRequestWriter = new SpidSAMLRequestWriter(StaxUtil.getXMLStreamWriter(os));
         if (requestType instanceof AuthnRequestType) {
-            SpidSAMLRequestWriter.write((AuthnRequestType) requestType);
+            samlRequestWriter.write((AuthnRequestType) requestType);
         } else if (requestType instanceof LogoutRequestType) {
-            SpidSAMLRequestWriter.write((LogoutRequestType) requestType);
+            samlRequestWriter.write((LogoutRequestType) requestType);
         } else
             throw logger.unsupportedType(requestType.getClass().getName());
     }
@@ -314,14 +346,15 @@ public class SpidSAML2Request {
      *
      * @param requestType
      * @param writer
+     *
      * @throws ProcessingException
      */
     public static void marshall(RequestAbstractType requestType, Writer writer) throws ProcessingException {
-        SpidSAMLRequestWriter SpidSAMLRequestWriter = new SpidSAMLRequestWriter(StaxUtil.getXMLStreamWriter(writer));
+        SpidSAMLRequestWriter samlRequestWriter = new SpidSAMLRequestWriter(StaxUtil.getXMLStreamWriter(writer));
         if (requestType instanceof AuthnRequestType) {
-            SpidSAMLRequestWriter.write((AuthnRequestType) requestType);
+            samlRequestWriter.write((AuthnRequestType) requestType);
         } else if (requestType instanceof LogoutRequestType) {
-            SpidSAMLRequestWriter.write((LogoutRequestType) requestType);
+            samlRequestWriter.write((LogoutRequestType) requestType);
         } else
             throw logger.unsupportedType(requestType.getClass().getName());
     }

--- a/src/main/java/it/redhat/spid/saml/SpidSAMLRequestWriter.java
+++ b/src/main/java/it/redhat/spid/saml/SpidSAMLRequestWriter.java
@@ -39,7 +39,6 @@ import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-
 import org.keycloak.dom.saml.v2.protocol.ExtensionsType;
 
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.ASSERTION_NSURI;
@@ -61,6 +60,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
      * Write a {@code AuthnRequestType } to stream
      *
      * @param request
+     *
      * @throws org.keycloak.saml.common.exceptions.ProcessingException
      */
     public void write(AuthnRequestType request) throws ProcessingException {
@@ -70,16 +70,12 @@ public class SpidSAMLRequestWriter extends BaseWriter {
 
         // Attributes
         StaxUtil.writeAttribute(writer, JBossSAMLConstants.ID.get(), request.getID());
-
         StaxUtil.writeAttribute(writer, JBossSAMLConstants.VERSION.get(), request.getVersion());
-
-
         StaxUtil.writeAttribute(writer, JBossSAMLConstants.ISSUE_INSTANT.get(), request.getIssueInstant().toString());
 
         URI destination = request.getDestination();
 
         StaxUtil.writeAttribute(writer, "AttributeConsumingServiceIndex", "1");
-
 
         if (destination != null)
             StaxUtil.writeAttribute(writer, JBossSAMLConstants.DESTINATION.get(), destination.toASCIIString());
@@ -102,7 +98,8 @@ public class SpidSAMLRequestWriter extends BaseWriter {
         Boolean isPassive = request.isIsPassive();
         if (isPassive != null) {
             StaxUtil.writeAttribute(writer, JBossSAMLConstants.IS_PASSIVE.get(), isPassive.toString());
-        }      */
+        }
+		*/
 
         URI protocolBinding = request.getProtocolBinding();
         if (protocolBinding != null) {
@@ -143,7 +140,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
         }
 
         ExtensionsType extensions = request.getExtensions();
-        if (extensions != null && !extensions.getAny().isEmpty()) {
+        if (extensions != null && ! extensions.getAny().isEmpty()) {
             write(extensions);
         }
 
@@ -171,6 +168,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
      * Write a {@code LogoutRequestType} to stream
      *
      * @param logOutRequest
+     *
      * @throws ProcessingException
      */
     public void write(LogoutRequestType logOutRequest) throws ProcessingException {
@@ -202,7 +200,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
         }
 
         ExtensionsType extensions = logOutRequest.getExtensions();
-        if (extensions != null && !extensions.getAny().isEmpty()) {
+        if (extensions != null && ! extensions.getAny().isEmpty()) {
             write(extensions);
         }
 
@@ -230,6 +228,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
      * Write a {@code NameIDPolicyType} to stream
      *
      * @param nameIDPolicy
+     *
      * @throws ProcessingException
      */
     public void write(NameIDPolicyType nameIDPolicy) throws ProcessingException {
@@ -259,6 +258,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
      * Write a {@code RequestedAuthnContextType} to stream
      *
      * @param requestedAuthnContextType
+     *
      * @throws ProcessingException
      */
     public void write(RequestedAuthnContextType requestedAuthnContextType) throws ProcessingException {
@@ -313,7 +313,7 @@ public class SpidSAMLRequestWriter extends BaseWriter {
             StaxUtil.writeDOMElement(writer, sig);
         }
         ExtensionsType extensions = request.getExtensions();
-        if (extensions != null && !extensions.getAny().isEmpty()) {
+        if (extensions != null && ! extensions.getAny().isEmpty()) {
             write(extensions);
         }
 
@@ -350,14 +350,12 @@ public class SpidSAMLRequestWriter extends BaseWriter {
         if (issuer != null) {
             write(issuer, new QName(ASSERTION_NSURI.get(), JBossSAMLConstants.ISSUER.get(), ASSERTION_PREFIX));
         }
-
-
         Element sig = request.getSignature();
         if (sig != null) {
             StaxUtil.writeDOMElement(writer, sig);
         }
         ExtensionsType extensions = request.getExtensions();
-        if (extensions != null && !extensions.getAny().isEmpty()) {
+        if (extensions != null && ! extensions.getAny().isEmpty()) {
             write(extensions);
         }
         SubjectType subject = request.getSubject();

--- a/src/main/java/it/redhat/spid/saml/SpidSAMLRequestWriter.java
+++ b/src/main/java/it/redhat/spid/saml/SpidSAMLRequestWriter.java
@@ -94,12 +94,11 @@ public class SpidSAMLRequestWriter extends BaseWriter {
             StaxUtil.writeAttribute(writer, JBossSAMLConstants.FORCE_AUTHN.get(), forceAuthn.toString());
         }
 
-        /*
+        // SPID: The IsPassive attribute isn't supported and shouldn't be in the assertion
         Boolean isPassive = request.isIsPassive();
-        if (isPassive != null) {
+        if (isPassive != null && isPassive == true) {
             StaxUtil.writeAttribute(writer, JBossSAMLConstants.IS_PASSIVE.get(), isPassive.toString());
         }
-		*/
 
         URI protocolBinding = request.getProtocolBinding();
         if (protocolBinding != null) {
@@ -123,14 +122,6 @@ public class SpidSAMLRequestWriter extends BaseWriter {
 
         NameIDType issuer = request.getIssuer();
         if (issuer != null) {
-            //@spid: attributes for Spid Auth
-            try {
-                issuer.setFormat(new URI("urn:oasis:names:tc:SAML:2.0:nameid-format:entity"));
-                issuer.setNameQualifier("http://rhsso.test.spid.it");
-            } catch (URISyntaxException e) {
-                e.printStackTrace();
-                throw new ProcessingException(e);
-            }
             write(issuer, new QName(ASSERTION_NSURI.get(), JBossSAMLConstants.ISSUER.get(), ASSERTION_PREFIX));
         }
 

--- a/src/main/java/it/redhat/spid/saml/mappers/SpidUserAttributeMapper.java
+++ b/src/main/java/it/redhat/spid/saml/mappers/SpidUserAttributeMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.spid.saml.mappers;
+
+import it.redhat.spid.provider.SpidIdentityProviderFactory;
+import org.keycloak.broker.saml.mappers.UserAttributeMapper;
+
+public class SpidUserAttributeMapper extends UserAttributeMapper {
+
+    public static final String[] COMPATIBLE_PROVIDERS = {SpidIdentityProviderFactory.PROVIDER_ID};
+
+    public static final String PROVIDER_ID = "spid-user-attribute-idp-mapper";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String[] getCompatibleProviders() {
+        return COMPATIBLE_PROVIDERS;
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "Attribute Importer";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "SPID Attribute Importer";
+    }
+}

--- a/src/main/java/it/redhat/spid/saml/mappers/SpidUsernameTemplateMapper.java
+++ b/src/main/java/it/redhat/spid/saml/mappers/SpidUsernameTemplateMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.spid.saml.mappers;
+
+import it.redhat.spid.provider.SpidIdentityProviderFactory;
+import org.keycloak.broker.saml.mappers.UsernameTemplateMapper;
+
+public class SpidUsernameTemplateMapper extends UsernameTemplateMapper  {
+
+    public static final String[] COMPATIBLE_PROVIDERS = {SpidIdentityProviderFactory.PROVIDER_ID};
+
+    public static final String PROVIDER_ID = "spid-saml-username-idp-mapper";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String[] getCompatibleProviders() {
+        return COMPATIBLE_PROVIDERS;
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "Preprocessor";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "SPID Username Template Importer";
+    }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -1,0 +1,2 @@
+it.redhat.spid.saml.mappers.SpidUsernameTemplateMapper
+it.redhat.spid.saml.mappers.SpidUserAttributeMapper


### PR DESCRIPTION
Implements configurable attribute mappers for the SPID Identity Provider and removes custom mapping logic from the Identity Provider. Had to bring in the commits from pull request #2 to avoid merge conflicts.